### PR TITLE
Allow MinGW compilation of ptools

### DIFF
--- a/ptools/fdtools.h
+++ b/ptools/fdtools.h
@@ -2,11 +2,10 @@
 #define FDTOOLS_H_
 
 extern "C" {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
     #include <io.h>
     #include <Winsock2.h>
     #include <string.h>
-    typedef unsigned __int64    ssize_t;
 #else
     #include <unistd.h>
     #include <netinet/in.h>
@@ -16,6 +15,10 @@ extern "C" {
 #endif
 #include <signal.h>
 #include <sys/types.h>
+
+#if defined(_MSC_VER)
+    typedef unsigned __int64    ssize_t;
+#endif
 
 };
 #include "ocval.h"
@@ -34,7 +37,7 @@ struct SockAddr_ {
 
   // Basic data of struct
   struct sockaddr addr;
-#if defined(OSF1_) || defined(_MSC_VER)
+#if defined(OSF1_) || defined(_MSC_VER) || defined(__MINGW32__)
   int             addrlen;
 #else
   socklen_t       addrlen;
@@ -430,7 +433,7 @@ class FDTools_ {
   virtual void closeUp_ (int& fd)
   {
     if (fd!=-1) {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
         int flag = SD_BOTH;
 #else
         int flag = SHUT_RDWR;

--- a/ptools/midassocket.cc
+++ b/ptools/midassocket.cc
@@ -1,7 +1,7 @@
 
 #include "midassocket.h"
 #include "socketerror.h"
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #else
 #include <netdb.h>   // for gethostbyname ... this causes conflicts
                      // on tru64 with X-Midas, so it has been moved to a .cc

--- a/ptools/midassocket.h
+++ b/ptools/midassocket.h
@@ -129,7 +129,7 @@ class MidasSocket_ : public FDTools_ {
   {
       if (forceShutdownOnClose_)
       {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
           int flag = SD_BOTH;
 #else
           int flag = SHUT_RDWR;

--- a/ptools/p2common.h
+++ b/ptools/p2common.h
@@ -6,7 +6,7 @@
 // implementation is fast.
 
 #include "cpickle.h"  // Python #defines 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #include <winsock2.h>
 #else
 #include <arpa/inet.h>


### PR DESCRIPTION
ptools doesn't build on MinGW as *nix socket headers are included. This patch selects Windows headers for MinGW builds.